### PR TITLE
Uncap client_max_body_size to resolve JupyterLab 413 error

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,6 +37,7 @@ http {
       proxy_set_header X-Forwarded-Protocol $scheme;
 
       proxy_read_timeout 600s;
+      client_max_body_size 0;
     }
 
     location /jupyter/ {
@@ -51,6 +52,7 @@ http {
       proxy_set_header X-Scheme $scheme;
       
       proxy_buffering off;
+      client_max_body_size 0;
     }
 
     location /api/res_avm/ {
@@ -68,6 +70,7 @@ http {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
       proxy_read_timeout 20d;
+      client_max_body_size 0;
     }
 
     location / {


### PR DESCRIPTION
Staff were receiving the following error when attempting to render large plots and dataframes in JupyterLab.

![image](https://github.com/ccao-data/service-nginx/assets/31494343/7d3d3149-52b7-45ff-9aa1-954dafd0a7f0)

Per [this issue](https://github.com/jupyterlab/jupyterlab/issues/4214) this seems to be resolved by uncapping the `client_max_body_size` parameter in nginx.